### PR TITLE
Add Functionality to Check Current IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Google Domains DDNS Updater
 Works well with `bash`.
 
+Forked to add the ability to check current IP before updating. Google has implemented rate limits and they'll block you if you request to change too often, so it seems like a good idea. 
+
 This script follows the [LSBInitScripts](https://wiki.debian.org/LSBInitScripts/).
 You can update your IP address every few minutes using `cron`, or update it at boot time using `init`.
 

--- a/init.d/update-ddns
+++ b/init.d/update-ddns
@@ -16,25 +16,17 @@ LOGFILE="/var/log/update-ddns.log"
 JSONFILE="/var/lib/update-ddns/example.json"
 #JSONFILE="example.json"
 
-if [ ! -f /var/lib/update-ddns/ip ]
-then
-touch /var/lib/update-ddns/ip
-fi
-
-IPFILE=$(cat "/var/lib/update-ddns/ip")
-CURRENT_IP=$(curl ifconfig.me)
-
 
 do_main()
 {	
-	if [[ $IPFILE == $CURRENT_IP ]]
+	REGISTERED_IP=$(dig +short $HOSTNAME)
+	PUBLIC_IP=$(curl ifconfig.me)
+	if [[ $REGISTERED_IP == $PUBLIC_IP ]]
 	then
 	printf "$(date) Current IP $CURRENT_IP has not changed, Exiting \n" >> $LOGFILE
 	exit 0
-	else 
-	echo $CURRENT_IP >> $IPFILE
 	fi
-	
+
 	
 	# Google Domains Dynamin DNS
 	if [ ! -z $4 ]

--- a/init.d/update-ddns
+++ b/init.d/update-ddns
@@ -10,14 +10,32 @@
 # Default-Stop:      0 1 6
 ### END INIT INFO
 
-#LOGFILE="/var/log/update-ddns.log"
-LOGFILE="example.log"
+LOGFILE="/var/log/update-ddns.log"
+#LOGFILE="example.log"
 
-#JSONFILE="/var/lib/update-ddns/example.json"
-JSONFILE="example.json"
+JSONFILE="/var/lib/update-ddns/example.json"
+#JSONFILE="example.json"
+
+if [ ! -f /var/lib/update-ddns/ip ]
+then
+touch /var/lib/update-ddns/ip
+fi
+
+IPFILE=$(cat "/var/lib/update-ddns/ip")
+CURRENT_IP=$(curl ifconfig.me)
+
 
 do_main()
-{
+{	
+	if [[ $IPFILE == $CURRENT_IP ]]
+	then
+	printf "$(date) Current IP $CURRENT_IP has not changed, Exiting \n" >> $LOGFILE
+	exit 0
+	else 
+	echo $CURRENT_IP >> $IPFILE
+	fi
+	
+	
 	# Google Domains Dynamin DNS
 	if [ ! -z $4 ]
 	then	local OUTPUT=$(wget -qO- --http-user="$2" --http-password="$3" "https://domains.google.com/nic/update?hostname=$1&myip=$4")

--- a/init.d/update-ddns
+++ b/init.d/update-ddns
@@ -10,11 +10,11 @@
 # Default-Stop:      0 1 6
 ### END INIT INFO
 
-LOGFILE="/var/log/update-ddns.log"
-#LOGFILE="example.log"
+#LOGFILE="/var/log/update-ddns.log"
+LOGFILE="example.log"
 
-JSONFILE="/var/lib/update-ddns/example.json"
-#JSONFILE="example.json"
+#JSONFILE="/var/lib/update-ddns/example.json"
+JSONFILE="example.json"
 
 
 do_main()


### PR DESCRIPTION
Per Google's doc page on their dynamic DNS API: 

https://support.google.com/domains/answer/6147083?hl=en#zippy=%2Cuse-the-api-to-update-your-dynamic-dns-record

"Make sure you interpret the response correctly, or you risk blocking your client from our system."
`nochg {user’s IP address} | Success | The supplied IP address is already set for this host. You should not attempt another update until your IP address changes.`
`abuse | Error | Dynamic DNS access for the hostname has been blocked due to failure to interpret previous responses correctly.`

Not sure what the rate limit is, but it seems like they really don't want you bothering them unless it needs to be changed. 

Added functionality to the do_main() function that will check if the current registered IP differs from the server's current public IP. If the two IPs are the same, it will exit and put a note in the log.